### PR TITLE
Refactors code from source @olange/h3-minimap Observable notebook

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -23,7 +23,7 @@
         "80abfffffffffff", "80e1fffffffffff", "80a5fffffffffff",
         "8035fffffffffff", "801ffffffffffff"
       ]'
-      world-geometry-src="https://cdn.jsdelivr.net/npm/world-atlas@2/countries-50m.json"
+      world-geometry-src="countries-50m.json"
       world-geometry-coll="countries">
       <p>This is child content</p>
     </h3-worldmap>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -137,10 +137,6 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
         </tr>
       
         <tr>
-          <td>isLoading</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
           <td>outlineGeom</td><td></td><td></td><td></td><td></td>
         </tr>
       

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -133,39 +133,11 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
         </tr>
       
         <tr>
-          <td>outlineGeom</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>areasGeom</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>centroid</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>bbox</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>bsphereGeom</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>hexesGeom</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
           <td>projFn</td><td></td><td></td><td></td><td></td>
         </tr>
       
         <tr>
           <td>pathFn</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>geometries</td><td></td><td></td><td></td><td></td>
         </tr>
       
         <tr>
@@ -222,6 +194,38 @@ execution flow:
     </table>
   
         
+    <h3>Methods</h3>
+    <table>
+      <tr>
+        <th>Name</th><th>Parameters</th><th>Description</th><th>Return</th>
+      </tr>
+      
+        <tr>
+          <td>outlineGeom</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>areasGeom</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>centroid</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>bbox</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>bsphereGeom</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>hexesGeom</td><td></td><td></td><td></td>
+        </tr>
+      
+    </table>
+  
         
     <h3>Events</h3>
     <table>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -133,14 +133,6 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
         </tr>
       
         <tr>
-          <td>projFn</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>pathFn</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
           <td>_SVGElement</td><td></td><td></td><td></td><td></td>
         </tr>
       
@@ -222,6 +214,14 @@ execution flow:
       
         <tr>
           <td>hexesGeom</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>projFn</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>pathFn</td><td></td><td></td><td></td>
         </tr>
       
     </table>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -133,10 +133,6 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
         </tr>
       
         <tr>
-          <td>viewBoxsize</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
           <td>outlineGeom</td><td></td><td></td><td></td><td></td>
         </tr>
       
@@ -166,6 +162,10 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
       
         <tr>
           <td>pathFn</td><td></td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>geometries</td><td></td><td></td><td></td><td></td>
         </tr>
       
         <tr>
@@ -222,18 +222,6 @@ execution flow:
     </table>
   
         
-    <h3>Methods</h3>
-    <table>
-      <tr>
-        <th>Name</th><th>Parameters</th><th>Description</th><th>Return</th>
-      </tr>
-      
-        <tr>
-          <td>geometries</td><td></td><td></td><td></td>
-        </tr>
-      
-    </table>
-  
         
     <h3>Events</h3>
     <table>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -133,10 +133,6 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
         </tr>
       
         <tr>
-          <td>_SVGElement</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
           <td>worldGeometrySrc</td><td>world-geometry-src</td><td>URL of a TopoJSON file describing the geometry of the world
 we'd like to display on the map. It is typically one of the
 World Atlases available from https://github.com/topojson/world-atlas</td><td>url</td><td></td>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -92,7 +92,7 @@ this attribute should take one of either collection names.</td><td>string</td><t
         </tr>
       
         <tr>
-          <td>_aspectRatio</td><td>Computed aspect ratio (width / height) of the client
+          <td>_svgClientRect</td><td>Computed aspect ratio (width / height) of the client
 rect of the map SVG Element.
 
 Defined after first update and paint, thru a complicated
@@ -106,7 +106,7 @@ execution flow:
    SVG element, compute its aspect ratio and set this state
    property accordingly;
 3. which will finally trigger a re-render of the SVG element
-   by Lit, with the correct aspect ratio being available.</td><td>number</td><td></td>
+   by Lit, with the correct aspect ratio being available.</td><td>object</td><td></td>
         </tr>
       
     </table>
@@ -129,7 +129,7 @@ For instance:
         <tr>
           <td>projection</td><td>projection</td><td>Geodesic projection identifier (a string matching one of
 the selected D3-geo projections that we support — see
-the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td>"orthographic"</td>
+the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td></td>
         </tr>
       
         <tr>
@@ -137,19 +137,11 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
         </tr>
       
         <tr>
-          <td>projFn</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>pathFn</td><td></td><td></td><td></td><td></td>
+          <td>isLoading</td><td></td><td></td><td></td><td></td>
         </tr>
       
         <tr>
           <td>outlineGeom</td><td></td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>_SVGElement</td><td></td><td></td><td></td><td></td>
         </tr>
       
         <tr>
@@ -173,9 +165,21 @@ the AVAILABLE_PROJECTIONS map definition in source code).</td><td>string</td><td
         </tr>
       
         <tr>
+          <td>projFn</td><td></td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>pathFn</td><td></td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>_SVGElement</td><td></td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
           <td>worldGeometrySrc</td><td>world-geometry-src</td><td>URL of a TopoJSON file describing the geometry of the world
 we'd like to display on the map. It is typically one of the
-World Atlases available from https://github.com/topojson/world-atlas</td><td>url</td><td>"https://cdn.jsdelivr.net/npm/world-atlas@2/land-110m.json"</td>
+World Atlases available from https://github.com/topojson/world-atlas</td><td>url</td><td></td>
         </tr>
       
         <tr>
@@ -185,11 +189,11 @@ geometry specified by the `worldGeometrySrc` property.
 
 For instance, the `countries-50m.json` TopoJSON world atlas [see below]
 contains two geometry collections, named `countries` and `land`;
-this attribute should take one of either collection names.</td><td>string</td><td>"land"</td>
+this attribute should take one of either collection names.</td><td>string</td><td></td>
         </tr>
       
         <tr>
-          <td>_aspectRatio</td><td>_aspectRatio</td><td>Computed aspect ratio (width / height) of the client
+          <td>_svgClientRect</td><td>_svgClientRect</td><td>Computed aspect ratio (width / height) of the client
 rect of the map SVG Element.
 
 Defined after first update and paint, thru a complicated
@@ -203,7 +207,12 @@ execution flow:
    SVG element, compute its aspect ratio and set this state
    property accordingly;
 3. which will finally trigger a re-render of the SVG element
-   by Lit, with the correct aspect ratio being available.</td><td>number</td><td>null</td>
+   by Lit, with the correct aspect ratio being available.</td><td>object</td><td>null</td>
+        </tr>
+      
+        <tr>
+          <td>_worldGeom</td><td>_worldGeom</td><td>World Atlas TopoJSON geometry, as loaded from the
+`world-geometry-src` and `world-geometry-coll` attributes.</td><td>object</td><td>undefined</td>
         </tr>
       
         <tr>
@@ -212,11 +221,6 @@ execution flow:
       
         <tr>
           <td>_projectionDef</td><td></td><td></td><td>null</td><td>null</td>
-        </tr>
-      
-        <tr>
-          <td>_worldGeom</td><td>_worldGeom</td><td>World Atlas TopoJSON geometry, as loaded from the
-`world-geometry-src` and `world-geometry-coll` attributes.</td><td>object</td><td>undefined</td>
         </tr>
       
     </table>
@@ -230,6 +234,10 @@ execution flow:
       
         <tr>
           <td>fetchLandData</td><td></td><td></td><td></td>
+        </tr>
+      
+        <tr>
+          <td>geometries</td><td></td><td></td><td></td>
         </tr>
       
     </table>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -229,10 +229,6 @@ execution flow:
       </tr>
       
         <tr>
-          <td>fetchLandData</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
           <td>geometries</td><td></td><td></td><td></td>
         </tr>
       

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -182,46 +182,6 @@ execution flow:
     </table>
   
         
-    <h3>Methods</h3>
-    <table>
-      <tr>
-        <th>Name</th><th>Parameters</th><th>Description</th><th>Return</th>
-      </tr>
-      
-        <tr>
-          <td>outlineGeom</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>areasGeom</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>centroid</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>bbox</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>bsphereGeom</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>hexesGeom</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>projFn</td><td></td><td></td><td></td>
-        </tr>
-      
-        <tr>
-          <td>pathFn</td><td></td><td></td><td></td>
-        </tr>
-      
-    </table>
-  
         
     <h3>Events</h3>
     <table>

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -258,7 +258,7 @@ export class H3Worldmap extends LitElement {
     return d3.geoPath( this.projFn);
   }
 
-  get geometries() {
+  _geometries() {
     return {
       outline: this.outlineGeom,
       graticule: null,
@@ -314,7 +314,7 @@ export class H3Worldmap extends LitElement {
 
   render() {
     return [
-      this._isLoading() ? spinnerView() : mapView(this._viewBoxSize(), this.pathFn, this.geometries),
+      this._isLoading() ? spinnerView() : mapView(this._viewBoxSize(), this.pathFn, this._geometries()),
       infoBoxView(this._uniqueAreas, this._projectionDef)
     ];
   }

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -143,7 +143,7 @@ export class H3Worldmap extends LitElement {
     this._projectionDef = null; // computed from `this._projection` (see `willUpdate()`)
   }
 
-  async fetchLandData() {
+  async _fetchWorldGeometry() {
     return fetch(this.worldGeometrySrc)
       .then(response => {
         if (!response.ok) {
@@ -291,10 +291,10 @@ export class H3Worldmap extends LitElement {
   }
 
   firstUpdated() {
-    // TODO: we should not ignore the promise returned
+    // TODO: we should not ignore the promise returned (see #19)
     // TODO: world geometry should be reloaded when
-    // worldGeometrySrc|Coll properties change
-    this.fetchLandData();
+    // worldGeometrySrc|Coll properties change (see #19)
+    this._fetchWorldGeometry();
 
     if (this._svgClientRect === null) {
       this._measureSVGElement();

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -270,7 +270,7 @@ export class H3Worldmap extends LitElement {
     }
   }
 
-  get _SVGElement() {
+  _SVGElement() {
     return this.renderRoot?.querySelector('svg#map') ?? null;
   }
 
@@ -289,7 +289,7 @@ export class H3Worldmap extends LitElement {
 
   _measureSVGElement() {
     return requestAnimationFrame(() => {
-      this._svgClientRect = this._SVGElement.getBoundingClientRect();
+      this._svgClientRect = this._SVGElement().getBoundingClientRect();
     });
   }
 

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -248,15 +248,15 @@ export class H3Worldmap extends LitElement {
     };
   }
 
-  get projFn() {
+  projFn() {
     const proj = this._projectionDef.ctorFn(),
       centroid = this.centroid();
     return proj.fitSize( this._viewBoxSize(), this.outlineGeom())
                .rotate( centroid[ 1], centroid[ 0]);
   }
 
-  get pathFn() {
-    return d3.geoPath( this.projFn);
+  pathFn() {
+    return d3.geoPath( this.projFn());
   }
 
   _geometries() {
@@ -315,7 +315,7 @@ export class H3Worldmap extends LitElement {
 
   render() {
     return [
-      this._isLoading() ? spinnerView() : mapView(this._viewBoxSize(), this.pathFn, this._geometries()),
+      this._isLoading() ? spinnerView() : mapView(this._viewBoxSize(), this.pathFn(), this._geometries()),
       infoBoxView(this._uniqueAreas, this._projectionDef)
     ];
   }

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -194,11 +194,6 @@ export class H3Worldmap extends LitElement {
       : [ 1000 * this._svgClientRect.width / this._svgClientRect.height, 1000 ];
   }
 
-  get isLoading() {
-    return this._svgClientRect === null
-           || this._worldGeom === null;
-  }
-
   get outlineGeom() {
     return { type: "Sphere" };
   }
@@ -267,6 +262,19 @@ export class H3Worldmap extends LitElement {
     return this.renderRoot?.querySelector('svg#map') ?? null;
   }
 
+  _hasMeasuredSVGSize() {
+    return this._svgClientRect !== null;
+  }
+
+  _hasLoadedWorldGeom() {
+    return this._worldGeom !== null;
+  }
+
+  _isLoading() {
+    return !( this._hasMeasuredSVGSize()
+           && this._hasLoadedWorldGeom());
+  }
+
   _measureSVGElement() {
     return requestAnimationFrame(() => {
       this._svgClientRect = this._SVGElement.getBoundingClientRect();
@@ -306,7 +314,7 @@ export class H3Worldmap extends LitElement {
 
   render() {
     return [
-      this.isLoading ? spinnerView() : mapView(this.viewBoxsize, this.pathFn, this.geometries()),
+      this._isLoading() ? spinnerView() : mapView(this.viewBoxsize, this.pathFn, this.geometries()),
       infoBoxView(this._uniqueAreas, this._projectionDef)
     ];
   }

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -5,153 +5,24 @@
  */
 
 import { LitElement, html, svg, css } from 'lit';
+
 import * as d3 from 'd3';
-import { h3IsValid, h3IsPentagon, h3ToGeoBoundary, getRes0Indexes } from 'h3-js';
 import * as topojson from 'topojson-client';
+import { h3IsValid, h3IsPentagon, h3ToGeoBoundary, getRes0Indexes } from 'h3-js';
+
+import { hostStyles } from './src/views/host.js';
+import { mapView, mapStyles } from './src/views/map.js';
+import { spinnerView, spinnerStyles } from './src/views/spinner.js';
+import { infoBoxView, infoStyles } from './src/views/infobox.js';
+
+import { AVAILABLE_PROJECTIONS } from './src/defs/projections.js';
+import { PROPS_DEFAULTS } from './src/defs/defaults.js';
 
 // Utility functions
 
 function removeDuplicates( arr) {
   return [...new Set(arr)];
 }
-
-// Styles
-
-const hostStyles = css`
-  :host {
-    height: 66vh;
-    box-sizing: border-box;
-    display: inline-block;
-    --primary-color: black;
-    --secondary-color: #dddddd;
-    --tertiary-color: #cccccc;
-    --highlight-color: #990000;
-    --areas-color: #cc0000cc;
-    --bounding-box-color: #ddddddcc;
-    --background-color: white;
-  }
-
-  svg, div { box-sizing: inherit }`;
-
-// SVG element will use all available space, but no more
-// (actual size constraints should be set on host)
-const mapStyles = css`
-  svg#map { width: 100%; height: 100%; }
-  .outline { fill: none; stroke: var(--secondary-color); stroke-width: 0.25%; }
-  .sphere { fill: var(--background-color); stroke: none; }
-  .land { fill: none; stroke: var(--primary-color); stroke-width: 0.15%; }
-  .graticule { fill: none; stroke: var(--secondary-color); }
-  .hexes { fill: none; stroke: var(--tertiary-color); stroke-width: 0.10%; }
-  .areas { fill: var(--areas-color); stroke: var(--highlight-color); stroke-width: 0.25%; }
-  .bbox { fill: none; stroke: var(--highlight-color); stroke-width: 0.25%; }`;
-
-const infoStyles = css`
-  div.info {
-    color: var(--primary-color);
-    border: 3px solid var(--primary-color); border-radius: 1.5rem;
-    padding: 1rem 1.5rem;
-  }
-  div.info code {
-    font-size: 1.3rem;
-  }`;
-
-const spinnerStyles = css`
-  .spinner {
-    animation: rotate 2s linear infinite;
-  }
-
-  .spinner circle {
-    animation: dash 1.5s ease-in-out infinite;
-    stroke: var(--primary-color);
-    stroke-linecap: round;
-    stroke-width: 2;
-    fill: var(--background-color);
-  }
-
-  @keyframes rotate {
-    100% { transform: rotate(360deg); }
-  }
-
-  @keyframes dash {
-    0% {
-      stroke-dasharray: 1, 150;
-      stroke-dashoffset: 0; }
-    50% {
-      stroke-dasharray: 90, 150;
-      stroke-dashoffset: -35; }
-    100% {
-      stroke-dasharray: 90, 150;
-      stroke-dashoffset: -124; }
-  }`;
-
-// Template fragments
-
-function infoBoxView(areas, projDef) {
-  return html`<div class="info">
-    ${areasView(areas)}<br>
-    ${projDefView(projDef)}
-    <slot></slot>
-  </div>`;
-}
-
-function areasView(areas) {
-  return html`Areas (<em>H3-indexes</em>): [ <strong>${areas?.map(
-    (area,i) =>
-      html`${i > 0 ? ', ' : ''}<code>${area}</code>`)}</strong> ]`;
-}
-
-function projDefView(projDef) {
-  return html`<strong>${projDef?.name}</strong>
-    projection (<code>${projDef?.id}</code>)`;
-}
-
-function spinnerView() {
-  // Important: id="map" must match the id used in `_SVGElement()`,
-  return svg`<svg id="map" viewBox="0 0 50 50" class="spinner">
-    <circle class="path" cx="25" cy="25" r="20" />
-  </svg>`;
-}
-
-function mapView(viewBoxSize, pathFn, geometries) {
-  // Important: id="map" must match the id used in `_SVGElement()`,
-  const [ width, height ] = viewBoxSize;
-  return svg`<svg id="map" viewBox="0 0 ${width} ${height}">
-    <defs>
-      <path id="outline" d="${pathFn(geometries.outline)}" />
-      <clipPath id="clip"><use xlink:href="#outline"/></clipPath>
-    </defs>
-    <g clip-path="#clip">
-      <use xlink:href="#outline" class="sphere" />
-      <!-- <path d="${pathFn(geometries.graticule)}" class="graticule" /> -->
-      <path d="${pathFn(geometries.hexes)}" class="hexes" />
-      <path d="${pathFn(geometries.world)}" class="land" />
-      <path d="${pathFn(geometries.bsphere)}" class="bbox" />
-      <path d="${pathFn(geometries.areas)}" class="areas" />
-    </g>
-    <use xlink:href="#outline" class="outline" />
-  </svg>`;
-}
-
-/**
- * Map of the projection identifiers, which are the possible values of the
- * 'projection' attribute of our custom element, with their corresponding
- * friendly name and D3 projection constructor function.
- *
- * It is (currently) a subset of projections we selected from the
- * [D3-geo](https://github.com/d3/d3-geo#projections) library.
- *
- * @constant
- * @default
- */
-const AVAILABLE_PROJECTIONS = new Map([
-  [ "conicEqualArea", { id: "conicEqualArea", name: "Conic equal-area", ctorFn: d3.geoConicEqualArea } ],
-  [ "orthographic",   { id: "orthographic", name: "Orthographic", ctorFn: d3.geoOrthographic } ],
-  [ "naturalEarth",   { id: "naturalEarth", name: "Natural Earth", ctorFn: d3.geoNaturalEarth1 } ],
-  [ "stereographic",  { id: "stereographic", name: "Stereographic", ctorFn: d3.geoStereographic } ],
-  [ "gnomonic",       { id: "gnomonic", name: "Gnomonic", ctorFn: d3.geoGnomonic } ],
-  [ "mercator",       { id: "mercator", name: "Mercator", ctorFn: d3.geoMercator } ],
-  // TODO: complete list from https://observablehq.com/@d3/projection-comparison
-]);
 
 /**
  * ‹h3-worldmap› custom element.
@@ -258,19 +129,18 @@ export class H3Worldmap extends LitElement {
     super();
 
     // Public attributes/properties (observed by Lit)
-    this.projection = "orthographic";    // will trigger its property setter
-    this.areas = [];                     // will trigger its property setter
-    this.worldGeometrySrc = "https://cdn.jsdelivr.net/npm/world-atlas@2/land-110m.json";
-    this.worldGeometryColl = "land";
+    this.projection = PROPS_DEFAULTS.PROJECTION; // will trigger its property setter
+    this.areas = []; // will trigger its property setter
+    this.worldGeometrySrc = PROPS_DEFAULTS.WORLD_GEOMETRY_SRC;
+    this.worldGeometryColl = PROPS_DEFAULTS.WORLD_GEOMETRY_COLL;
 
     // Internal state properties (observed by Lit)
-    this._svgClientRect = null;          // computed after first paint
-    this._worldGeom = undefined;          // defined once the TOPOJson world geometry has loaded
+    this._svgClientRect = null; // computed after first paint
+    this._worldGeom = undefined; // defined once the TOPOJson world geometry has loaded
 
     // Internal private properties (derived, not observed)
-    this._uniqueAreas = null;            // computed from `this._areas` (see `willUpdate()`)
-    this._projectionDef = null;          // computed from `this._projection` (see `willUpdate()`)
-
+    this._uniqueAreas = null;   // computed from `this._areas` (see `willUpdate()`)
+    this._projectionDef = null; // computed from `this._projection` (see `willUpdate()`)
   }
 
   async fetchLandData() {

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -187,10 +187,10 @@ export class H3Worldmap extends LitElement {
     this.requestUpdate("projection", oldId);
   }
 
-  get viewBoxsize() {
+  _viewBoxSize() {
     // Returns width and height of the SVG viewbox space, which is used to
     // configure the D3-geo projection to produce coordinates in this space
-    return (this._svgClientRect === null)? null
+    return (this._svgClientRect === null) ? null
       : [ 1000 * this._svgClientRect.width / this._svgClientRect.height, 1000 ];
   }
 
@@ -250,12 +250,23 @@ export class H3Worldmap extends LitElement {
 
   get projFn() {
     const proj = this._projectionDef.ctorFn();
-    return proj.fitSize( this.viewBoxsize, this.outlineGeom)
+    return proj.fitSize( this._viewBoxSize(), this.outlineGeom)
                .rotate( this.centroid[ 1], this.centroid[ 0]);
   }
 
   get pathFn() {
     return d3.geoPath( this.projFn);
+  }
+
+  get geometries() {
+    return {
+      outline: this.outlineGeom,
+      graticule: null,
+      hexes: this.hexesGeom,
+      world: this._worldGeom,
+      bsphere: this.bsphereGeom,
+      areas: this.areasGeom
+    }
   }
 
   get _SVGElement() {
@@ -301,20 +312,9 @@ export class H3Worldmap extends LitElement {
     }
   }
 
-  geometries() {
-    return {
-      outline: this.outlineGeom,
-      graticule: null,
-      hexes: this.hexesGeom,
-      world: this._worldGeom,
-      bsphere: this.bsphereGeom,
-      areas: this.areasGeom
-    }
-  }
-
   render() {
     return [
-      this._isLoading() ? spinnerView() : mapView(this.viewBoxsize, this.pathFn, this.geometries()),
+      this._isLoading() ? spinnerView() : mapView(this._viewBoxSize(), this.pathFn, this.geometries),
       infoBoxView(this._uniqueAreas, this._projectionDef)
     ];
   }

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -194,11 +194,11 @@ export class H3Worldmap extends LitElement {
       : [ 1000 * this._svgClientRect.width / this._svgClientRect.height, 1000 ];
   }
 
-  get outlineGeom() {
+  outlineGeom() {
     return { type: "Sphere" };
   }
 
-  get areasGeom() {
+  areasGeom() {
     return {
       type: "FeatureCollection",
       features: this._areas.map((area) => ({
@@ -212,26 +212,26 @@ export class H3Worldmap extends LitElement {
     };
   }
 
-  get centroid() {
-    return d3.geoCentroid(this.areasGeom);
+  centroid() {
+    return d3.geoCentroid(this.areasGeom());
   }
 
-  get bbox() {
+  bbox() {
     const [[minLon, minLat], [maxLon, maxLat]] = d3.geoBounds(
-      this.areasGeom
+      this.areasGeom()
     );
     return { minLat, minLon, maxLat, maxLon };
   }
 
-  get bsphereGeom() {
-    const { minLat, minLon, maxLat, maxLon } = this.bbox;
+  bsphereGeom() {
+    const { minLat, minLon, maxLat, maxLon } = this.bbox();
     const radius =
       Math.max(Math.abs(maxLat - minLat), Math.abs(maxLon - minLon)) / 1.9;
-    const geoCircle = d3.geoCircle().center(this.centroid).radius(radius);
+    const geoCircle = d3.geoCircle().center(this.centroid()).radius(radius);
     return geoCircle();
   }
 
-  get hexesGeom() {
+  hexesGeom() {
     return {
       type: "FeatureCollection",
       features: getRes0Indexes()
@@ -249,9 +249,10 @@ export class H3Worldmap extends LitElement {
   }
 
   get projFn() {
-    const proj = this._projectionDef.ctorFn();
-    return proj.fitSize( this._viewBoxSize(), this.outlineGeom)
-               .rotate( this.centroid[ 1], this.centroid[ 0]);
+    const proj = this._projectionDef.ctorFn(),
+      centroid = this.centroid();
+    return proj.fitSize( this._viewBoxSize(), this.outlineGeom())
+               .rotate( centroid[ 1], centroid[ 0]);
   }
 
   get pathFn() {
@@ -260,12 +261,12 @@ export class H3Worldmap extends LitElement {
 
   _geometries() {
     return {
-      outline: this.outlineGeom,
+      outline: this.outlineGeom(),
       graticule: null,
-      hexes: this.hexesGeom,
+      hexes: this.hexesGeom(),
       world: this._worldGeom,
-      bsphere: this.bsphereGeom,
-      areas: this.areasGeom
+      bsphere: this.bsphereGeom(),
+      areas: this.areasGeom()
     }
   }
 

--- a/src/core/geometries.js
+++ b/src/core/geometries.js
@@ -1,0 +1,55 @@
+import * as d3 from 'd3';
+import { h3IsPentagon, h3ToGeoBoundary, getRes0Indexes } from 'h3-js';
+
+export function outlineGeom() {
+  return { type: "Sphere" };
+}
+
+export function areasGeom(areas) {
+  return {
+    type: "FeatureCollection",
+    features: areas.map((area) => ({
+      type: "Feature",
+      properties: { id: area, pentagon: h3IsPentagon(area) },
+      geometry: {
+        type: "Polygon",
+        coordinates: [h3ToGeoBoundary(area, true).reverse()]
+      }
+    }))
+  };
+}
+
+export function centroid(areasGeom) {
+  return d3.geoCentroid(areasGeom);
+}
+
+function bbox(areasGeom) {
+  const [[minLon, minLat], [maxLon, maxLat]] = d3.geoBounds(areasGeom);
+  return { minLat, minLon, maxLat, maxLon };
+}
+
+export function bsphereGeom(areasGeom) {
+  const { minLat, minLon, maxLat, maxLon } = bbox(areasGeom);
+  const radius =
+    Math.max(Math.abs(maxLat - minLat), Math.abs(maxLon - minLon)) / 1.9;
+  const geoCentroid = centroid( areasGeom);
+  const geoCircle = d3.geoCircle().center(geoCentroid).radius(radius);
+  return geoCircle();
+}
+
+export function hexesGeom() {
+  return {
+    type: "FeatureCollection",
+    features: getRes0Indexes()
+      // .map( i => h3ToChildren( i, level))
+      .flat()
+      .map( d => ({
+        type: "Feature",
+        properties: { id: d, pentagon: h3IsPentagon(d) },
+        geometry: {
+          type: "Polygon",
+          coordinates: [ h3ToGeoBoundary(d, true).reverse() ]
+        }
+      }))
+  };
+}

--- a/src/defs/defaults.js
+++ b/src/defs/defaults.js
@@ -1,0 +1,6 @@
+// Default values of the ‹h3-worldmap› public properties
+export const PROPS_DEFAULTS = {
+  WORLD_GEOMETRY_SRC: "https://cdn.jsdelivr.net/npm/world-atlas@2/land-110m.json",
+  WORLD_GEOMETRY_COLL: "land",
+  PROJECTION: "orthographic"
+}

--- a/src/defs/projections.js
+++ b/src/defs/projections.js
@@ -1,0 +1,22 @@
+import * as d3 from 'd3';
+
+/**
+ * Map of the projection identifiers, which are the possible values of the
+ * 'projection' attribute of our custom element, with their corresponding
+ * friendly name and D3 projection constructor function.
+ *
+ * It is (currently) a subset of projections we selected from the
+ * [D3-geo](https://github.com/d3/d3-geo#projections) library.
+ *
+ * @constant
+ * @default
+ */
+ export const AVAILABLE_PROJECTIONS = new Map([
+  [ "conicEqualArea", { id: "conicEqualArea", name: "Conic equal-area", ctorFn: d3.geoConicEqualArea } ],
+  [ "orthographic",   { id: "orthographic", name: "Orthographic", ctorFn: d3.geoOrthographic } ],
+  [ "naturalEarth",   { id: "naturalEarth", name: "Natural Earth", ctorFn: d3.geoNaturalEarth1 } ],
+  [ "stereographic",  { id: "stereographic", name: "Stereographic", ctorFn: d3.geoStereographic } ],
+  [ "gnomonic",       { id: "gnomonic", name: "Gnomonic", ctorFn: d3.geoGnomonic } ],
+  [ "mercator",       { id: "mercator", name: "Mercator", ctorFn: d3.geoMercator } ],
+  // TODO: complete list from https://observablehq.com/@d3/projection-comparison
+]);

--- a/src/views/host.js
+++ b/src/views/host.js
@@ -1,0 +1,18 @@
+import { css } from 'lit';
+
+export const hostStyles = css`
+  :host {
+    height: 66vh;
+    box-sizing: border-box;
+    display: inline-block;
+    --primary-color: black;
+    --secondary-color: #dddddd;
+    --tertiary-color: #cccccc;
+    --highlight-color: #990000;
+    --areas-color: #cc0000cc;
+    --bounding-box-color: #ddddddcc;
+    --background-color: white;
+  }
+
+  svg, div { box-sizing: inherit }
+`;

--- a/src/views/infobox.js
+++ b/src/views/infobox.js
@@ -1,0 +1,30 @@
+import { html, css } from 'lit';
+
+export const infoStyles = css`
+  div.info {
+    color: var(--primary-color);
+    border: 3px solid var(--primary-color); border-radius: 1.5rem;
+    padding: 1rem 1.5rem;
+  }
+  div.info code {
+    font-size: 1.3rem;
+  }`;
+
+function areasView(areas) {
+  return html`Areas (<em>H3-indexes</em>): [ <strong>${areas?.map(
+    (area,i) =>
+      html`${i > 0 ? ', ' : ''}<code>${area}</code>`)}</strong> ]`;
+}
+
+function projDefView(projDef) {
+  return html`<strong>${projDef?.name}</strong>
+    projection (<code>${projDef?.id}</code>)`;
+}
+
+export function infoBoxView(areas, projDef) {
+  return html`<div class="info">
+      ${areasView(areas)}<br>
+      ${projDefView(projDef)}
+      <slot></slot>
+    </div>`;
+}

--- a/src/views/map.js
+++ b/src/views/map.js
@@ -1,0 +1,34 @@
+import { svg, css } from 'lit';
+
+// Our SVG canvas element will use all available space, but no more
+// (actual size constraints should be set on host)
+
+export const mapStyles = css`
+  svg#map { width: 100%; height: 100%; }
+  .outline { fill: none; stroke: var(--secondary-color); stroke-width: 0.25%; }
+  .sphere { fill: var(--background-color); stroke: none; }
+  .land { fill: none; stroke: var(--primary-color); stroke-width: 0.15%; }
+  .graticule { fill: none; stroke: var(--secondary-color); }
+  .hexes { fill: none; stroke: var(--tertiary-color); stroke-width: 0.10%; }
+  .areas { fill: var(--areas-color); stroke: var(--highlight-color); stroke-width: 0.25%; }
+  .bbox { fill: none; stroke: var(--highlight-color); stroke-width: 0.25%; }`;
+
+export function mapView(viewBoxSize, pathFn, geometries) {
+  // Important: id="map" must match the id used in `_SVGElement()` getter
+  const [ width, height ] = viewBoxSize;
+  return svg`<svg id="map" viewBox="0 0 ${width} ${height}">
+    <defs>
+      <path id="outline" d="${pathFn(geometries.outline)}" />
+      <clipPath id="clip"><use xlink:href="#outline"/></clipPath>
+    </defs>
+    <g clip-path="#clip">
+      <use xlink:href="#outline" class="sphere" />
+      <!-- <path d="${pathFn(geometries.graticule)}" class="graticule" /> -->
+      <path d="${pathFn(geometries.hexes)}" class="hexes" />
+      <path d="${pathFn(geometries.world)}" class="land" />
+      <path d="${pathFn(geometries.bsphere)}" class="bbox" />
+      <path d="${pathFn(geometries.areas)}" class="areas" />
+    </g>
+    <use xlink:href="#outline" class="outline" />
+  </svg>`;
+}

--- a/src/views/spinner.js
+++ b/src/views/spinner.js
@@ -1,0 +1,39 @@
+import { svg, css } from 'lit';
+
+export function spinnerView() {
+  // Important: id="map" must match the id used in `_SVGElement()` getter
+  return svg`<svg id="map" viewBox="0 0 50 50" class="spinner">
+      <circle class="path" cx="25" cy="25" r="20" />
+    </svg>
+  `;
+}
+
+export const spinnerStyles = css`
+  .spinner {
+    animation: rotate 2s linear infinite;
+  }
+
+  .spinner circle {
+    animation: dash 1.5s ease-in-out infinite;
+    stroke: var(--primary-color);
+    stroke-linecap: round;
+    stroke-width: 2;
+    fill: var(--background-color);
+  }
+
+  @keyframes rotate {
+    100% { transform: rotate(360deg); }
+  }
+
+  @keyframes dash {
+    0% {
+      stroke-dasharray: 1, 150;
+      stroke-dashoffset: 0; }
+    50% {
+      stroke-dasharray: 90, 150;
+      stroke-dashoffset: -35; }
+    100% {
+      stroke-dasharray: 90, 150;
+      stroke-dashoffset: -124; }
+  }
+`;


### PR DESCRIPTION
* Externalizes all views, projection and default settings to separate files (`src/{defs,views}/*.js`)
* Recasts `isLoading` public getter as private method
* Recasts `fetchWorldGeometry` public method as private
* Recasts `viewBoxsize` public getter as private method
* Recasts `geometry` public getter as private method
* Recasts geometry getters as methods
* Recasts projFn|pathFn getters as methods
* Recasts `_svgElement` private getter as method
* Externalizes geometry builder methods to separate file (`src/core/geometries.js`)
