### PR TITLE
projections.js: remove property “id”

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,6 @@
   "tabWidth": 2,
   "singleQuote": true,
   "bracketSpacing": false,
-  "arrowParens": "always"
+  "arrowParens": "always",
+  "requirePragma": true
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,6 +3,5 @@
   "tabWidth": 2,
   "singleQuote": true,
   "bracketSpacing": false,
-  "arrowParens": "always",
-  "requirePragma": true
+  "arrowParens": "always"
 }

--- a/h3-worldmap.js
+++ b/h3-worldmap.js
@@ -244,7 +244,13 @@ export class H3Worldmap extends LitElement {
 
   willUpdate(changedProperties) {
     if (changedProperties.has('projection')) {
-      this._projectionDef = AVAILABLE_PROJECTIONS.get( this._projection);
+      /* Add `id` to the this._projectionDef property.
+         Note that `id` is used only in the infoBox to identify the projection.
+         If the infoBox is removed or simplifieed, `id` becomes useless,
+         and the line below can be simplified to: 
+          this._projectionDef = AVAILABLE_PROJECTIONS.get( this._projection);
+      */
+      this._projectionDef = {id: this._projection, ...AVAILABLE_PROJECTIONS.get( this._projection)};
     }
     if (changedProperties.has('areas')) {
       this._uniqueAreas = removeDuplicates(this._areas);

--- a/src/defs/projections.js
+++ b/src/defs/projections.js
@@ -12,11 +12,11 @@ import * as d3 from 'd3';
  * @default
  */
  export const AVAILABLE_PROJECTIONS = new Map([
-  [ "conicEqualArea", { id: "conicEqualArea", name: "Conic equal-area", ctorFn: d3.geoConicEqualArea } ],
-  [ "orthographic",   { id: "orthographic", name: "Orthographic", ctorFn: d3.geoOrthographic } ],
-  [ "naturalEarth",   { id: "naturalEarth", name: "Natural Earth", ctorFn: d3.geoNaturalEarth1 } ],
-  [ "stereographic",  { id: "stereographic", name: "Stereographic", ctorFn: d3.geoStereographic } ],
-  [ "gnomonic",       { id: "gnomonic", name: "Gnomonic", ctorFn: d3.geoGnomonic } ],
-  [ "mercator",       { id: "mercator", name: "Mercator", ctorFn: d3.geoMercator } ],
+  [ "conicEqualArea", { name: "Conic equal-area", ctorFn: d3.geoConicEqualArea } ],
+  [ "orthographic",   { name: "Orthographic", ctorFn: d3.geoOrthographic } ],
+  [ "naturalEarth",   { name: "Natural Earth", ctorFn: d3.geoNaturalEarth1 } ],
+  [ "stereographic",  { name: "Stereographic", ctorFn: d3.geoStereographic } ],
+  [ "gnomonic",       { name: "Gnomonic", ctorFn: d3.geoGnomonic } ],
+  [ "mercator",       { name: "Mercator", ctorFn: d3.geoMercator } ],
   // TODO: complete list from https://observablehq.com/@d3/projection-comparison
 ]);


### PR DESCRIPTION
1. `projections.js`: remove property `id`
2. `h3-worldmap.js`: modify code in `willUpdate` to recover `id` for the sole use in the `infoBox`: 
3. `prettier.json`: add `"requirePragma": true` to protect hand-formatted files against prettier formatting

Note: if and when we remove the `infoBox`, we can revert the change 2. above (29.04 OL: ok, j'ai transcrit cette indication dans #9).

This PR replaces the PR#15, which can be rejected and closed.